### PR TITLE
chore: use published blstrs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ subtle = { version = "2.4.1", default-features = false }
 sha3 = { version = "0.9.1", default-features = false }
 rand_chacha = "0.3" # used as a seedable rng in GeneratorsxChain
 digest = { version = "0.9.0", default-features = false }
-rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
-rand = { version = "0.8", default-features = false, optional = true }
+rand = "0.8.5"
 byteorder = { version = "1", default-features = false }
 serde = { version = "1", default-features = false, features = ["alloc"] }
 serde_derive = { version = "1", default-features = false }
@@ -41,7 +40,7 @@ rand_chacha = "0.3"
 [features]
 default = ["std"]
 yoloproofs = []
-std = ["rand", "rand/std", "rand/std_rng", "thiserror"]
+std = ["thiserror"]
 nightly = ["subtle/nightly", "clear_on_drop/nightly"]
 docs = ["nightly"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ description = "A pure-Rust implementation of Bulletproofs using Ristretto"
 edition = "2018"
 
 [dependencies]
-blstrs = { git = "https://github.com/davidrusu/blstrs.git", branch="bulletproofs-fixes" }
-# curve25519-dalek = { package = "curve25519-dalek-ng", version = "4", default-features = false, features = ["u64_backend", "serde"] }
+blstrs = "0.4.2"
 subtle = { version = "2.4.1", default-features = false }
 sha3 = { version = "0.9.1", default-features = false }
 rand_chacha = "0.3" # used as a seedable rng in GeneratorsxChain
@@ -31,6 +30,7 @@ serde_derive = { version = "1", default-features = false }
 thiserror = { version = "1", optional = true }
 merlin = { version = "3", default-features = false }
 clear_on_drop = { version = "0.2", default-features = false }
+group = "0.11.0"
 
 [dev-dependencies]
 hex = "0.3"
@@ -40,11 +40,8 @@ rand_chacha = "0.3"
 
 [features]
 default = ["std"]
-# avx2_backend = ["curve25519-dalek/avx2_backend"]
 yoloproofs = []
-#std = ["rand", "rand/std", "rand/std_rng", "thiserror", "curve25519-dalek/std"]
 std = ["rand", "rand/std", "rand/std_rng", "thiserror"]
-# nightly = ["curve25519-dalek/nightly", "curve25519-dalek/alloc", "subtle/nightly", "clear_on_drop/nightly"]
 nightly = ["subtle/nightly", "clear_on_drop/nightly"]
 docs = ["nightly"]
 

--- a/src/generators.rs
+++ b/src/generators.rs
@@ -7,8 +7,9 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use blstrs::{group::Group, G1Projective, Scalar};
+use blstrs::{G1Projective, Scalar};
 use digest::Digest;
+use group::Group;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use sha3::Sha3_256;

--- a/src/inner_product_proof.rs
+++ b/src/inner_product_proof.rs
@@ -6,9 +6,9 @@ extern crate alloc;
 use alloc::borrow::Borrow;
 use alloc::vec::Vec;
 
-use blstrs::group::ff::Field;
 use blstrs::{G1Projective, Scalar};
 use core::iter;
+use group::ff::Field;
 use merlin::Transcript;
 
 use crate::errors::ProofError;
@@ -227,7 +227,10 @@ impl InnerProductProof {
             .into_iter()
             .map(|u| Option::from(u.invert()).ok_or(ProofError::FormatError))
             .collect::<Result<Vec<_>, _>>()?;
-        let allinv = challenges_inv.iter().product();
+        // todo: replace fold() with product() when supported in blstrs
+        let allinv = challenges_inv
+            .iter()
+            .fold(Scalar::one(), |product, x| product * x);
 
         // 3. Compute u_i^2 and (1/u_i)^2
 
@@ -328,6 +331,7 @@ impl InnerProductProof {
     /// The layout of the inner product proof is:
     /// * \\(n\\) pairs of compressed Ristretto points \\(L_0, R_0 \dots, L_{n-1}, R_{n-1}\\),
     /// * two scalars \\(a, b\\).
+    #[allow(dead_code)]
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(self.serialized_size());
         for (l, r) in self.L_vec.iter().zip(self.R_vec.iter()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,13 @@ mod inner_product_proof;
 mod range_proof;
 mod transcript;
 
+// re-export crates that are used in our public API.
+pub use blstrs;
+pub use group;
+pub use merlin;
+pub use rand;
+pub use rand_core;
+
 pub use crate::errors::ProofError;
 pub use crate::generators::{BulletproofGens, BulletproofGensShare, PedersenGens};
 pub use crate::range_proof::RangeProof;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,6 @@ pub use blstrs;
 pub use group;
 pub use merlin;
 pub use rand;
-pub use rand_core;
 
 pub use crate::errors::ProofError;
 pub use crate::generators::{BulletproofGens, BulletproofGensShare, PedersenGens};

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -10,9 +10,9 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use blstrs::group::ff::Field;
-use blstrs::group::Curve;
 use blstrs::{G1Projective, Scalar};
+use group::ff::Field;
+use group::Curve;
 use merlin::Transcript;
 
 use crate::errors::MPCError;
@@ -243,9 +243,19 @@ impl<'a, 'b> DealerAwaitingProofShares<'a, 'b> {
             return Err(MPCError::MalformedProofShares { bad_shares }.into());
         }
 
-        let t_x: Scalar = proof_shares.iter().map(|ps| ps.t_x).sum();
-        let t_x_blinding: Scalar = proof_shares.iter().map(|ps| ps.t_x_blinding).sum();
-        let e_blinding: Scalar = proof_shares.iter().map(|ps| ps.e_blinding).sum();
+        // todo: replace fold() with sum() when supported in blstrs
+        let t_x: Scalar = proof_shares
+            .iter()
+            .map(|ps| ps.t_x)
+            .fold(Scalar::zero(), |sum, x| sum + x);
+        let t_x_blinding: Scalar = proof_shares
+            .iter()
+            .map(|ps| ps.t_x_blinding)
+            .fold(Scalar::zero(), |sum, x| sum + x);
+        let e_blinding: Scalar = proof_shares
+            .iter()
+            .map(|ps| ps.e_blinding)
+            .fold(Scalar::zero(), |sum, x| sum + x);
 
         self.transcript.append_scalar(b"t_x", &t_x);
         self.transcript

--- a/src/range_proof/dealer.rs
+++ b/src/range_proof/dealer.rs
@@ -21,7 +21,7 @@ use crate::range_proof::RangeProof;
 use crate::transcript::TranscriptProtocol;
 use crate::{inner_product_proof, ProofError};
 
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 
 use crate::util;
 

--- a/src/range_proof/messages.rs
+++ b/src/range_proof/messages.rs
@@ -7,11 +7,9 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use blstrs::{
-    group::{ff::Field, Group},
-    G1Projective, Scalar,
-};
+use blstrs::{G1Projective, Scalar};
 use core::iter;
+use group::{ff::Field, Group};
 
 use crate::generators::{BulletproofGens, PedersenGens};
 

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -8,8 +8,8 @@ extern crate rand;
 #[cfg(feature = "std")]
 use self::rand::thread_rng;
 use alloc::vec::Vec;
-use blstrs::group::ff::Field;
-use blstrs::group::{Curve, Group};
+use group::ff::Field;
+use group::{Curve, Group};
 
 use core::iter;
 
@@ -86,7 +86,8 @@ impl RangeProof {
     /// use rand::thread_rng;
     ///
     /// extern crate blstrs;
-    /// use blstrs::{group::ff::Field, Scalar};
+    /// use group::ff::Field;
+    /// use blstrs::Scalar;
     ///
     /// extern crate merlin;
     /// use merlin::Transcript;
@@ -185,7 +186,8 @@ impl RangeProof {
     /// use rand::thread_rng;
     ///
     /// extern crate blstrs;
-    /// use blstrs::{group::ff::Field, Scalar};
+    /// use group::ff::Field;
+    /// use blstrs::Scalar;
     ///
     /// extern crate merlin;
     /// use merlin::Transcript;

--- a/src/range_proof/mod.rs
+++ b/src/range_proof/mod.rs
@@ -22,7 +22,7 @@ use crate::inner_product_proof::InnerProductProof;
 use crate::transcript::TranscriptProtocol;
 use crate::util;
 
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 use serde::de::Visitor;
 use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
 

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -17,7 +17,7 @@ use blstrs::{G1Projective, Scalar};
 use clear_on_drop::clear::Clear;
 use core::iter;
 use group::ff::Field;
-use rand_core::{CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 
 use crate::errors::MPCError;
 use crate::generators::{BulletproofGens, PedersenGens};

--- a/src/range_proof/party.rs
+++ b/src/range_proof/party.rs
@@ -13,10 +13,10 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use blstrs::group::ff::Field;
 use blstrs::{G1Projective, Scalar};
 use clear_on_drop::clear::Clear;
 use core::iter;
+use group::ff::Field;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::errors::MPCError;

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -1,10 +1,8 @@
 //! Defines a `TranscriptProtocol` trait for using a Merlin transcript.
 
-use blstrs::{
-    group::{ff::Field, Group},
-    G1Projective, Scalar,
-};
+use blstrs::{G1Projective, Scalar};
 use digest::Digest;
+use group::{ff::Field, Group};
 use merlin::Transcript;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,9 +5,9 @@ extern crate alloc;
 
 use alloc::vec;
 use alloc::vec::Vec;
-use blstrs::group::ff::Field;
 use blstrs::Scalar;
 use clear_on_drop::clear::Clear;
+use group::ff::Field;
 
 use crate::inner_product_proof::inner_product;
 
@@ -258,7 +258,8 @@ pub fn sum_of_powers(x: &Scalar, n: usize) -> Scalar {
 
 // takes the sum of all of the powers of x, up to n
 fn sum_of_powers_slow(x: &Scalar, n: usize) -> Scalar {
-    exp_iter(*x).take(n).sum()
+    // todo: replace fold() with sum() when supported in blstrs
+    exp_iter(*x).take(n).fold(Scalar::zero(), |sum, x| sum + x)
 }
 
 /// Given `data` with `len >= 32`, return the first 32 bytes.

--- a/tests/range_proof.rs
+++ b/tests/range_proof.rs
@@ -1,4 +1,4 @@
-use rand_core::SeedableRng;
+use rand::SeedableRng;
 
 use rand_chacha::ChaChaRng;
 

--- a/tests/range_proof.rs
+++ b/tests/range_proof.rs
@@ -2,7 +2,9 @@ use rand_core::SeedableRng;
 
 use rand_chacha::ChaChaRng;
 
-use blstrs::{group::ff::Field, Scalar};
+use group::ff::Field;
+
+use blstrs::Scalar;
 
 use merlin::Transcript;
 


### PR DESCRIPTION
This enables crates that depend on blst-bulletproofs to use the
published blstrs instead of our fork.

* change blstrs dep from github fork to 0.4.2.
* add dep 'group'
* remove some commented deps
* update 'use' statements in src files
* replace calls to Scalar::{fsum(),product()) with fold()
* disable dead code compiler warning about to_bytes()

------

builds cleanly and all tests are passing on my machine.

```$ cargo test
   Compiling bulletproofs v4.0.0 (/home/danda/dev/maidsafe/blst-bulletproofs)
    Finished test [unoptimized + debuginfo] target(s) in 3.40s
     Running unittests (/home/danda/dev/maidsafe/blst-bulletproofs/target/debug/deps/bulletproofs-278a61216a8ba49a)

running 26 tests
test inner_product_proof::tests::make_ipp_1 ... ok
test inner_product_proof::tests::make_ipp_2 ... ok
test inner_product_proof::tests::make_ipp_4 ... ok
test generators::tests::aggregated_gens_iter_matches_flat_map ... ok
test inner_product_proof::tests::test_inner_product ... ok
test inner_product_proof::tests::make_ipp_32 ... ok
test inner_product_proof::tests::make_ipp_64 ... ok
test generators::tests::resizing_small_gens_matches_creating_bigger_gens ... ok
test range_proof::tests::create_and_verify_n_32_m_1 ... ok
test range_proof::tests::create_and_verify_n_32_m_2 ... ok
test range_proof::tests::create_and_verify_n_64_m_1 ... ok
test range_proof::tests::create_and_verify_n_32_m_4 ... ok
test range_proof::tests::create_and_verify_n_64_m_2 ... ok
test range_proof::tests::detect_dishonest_dealer_during_aggregation ... ok
test range_proof::tests::create_and_verify_n_32_m_8 ... ok
test range_proof::tests::test_delta ... ok
test util::tests::exp_2_is_powers_of_2 ... ok
test util::tests::test_inner_product ... ok
test util::tests::test_scalar_exp ... ok
test util::tests::test_sum_of_powers ... ok
test util::tests::test_sum_of_powers_slow ... ok
test util::tests::tuple_of_scalars_clear_on_drop ... ok
test util::tests::vec_of_scalars_clear_on_drop ... ok
test range_proof::tests::detect_dishonest_party_during_aggregation ... ok
test range_proof::tests::create_and_verify_n_64_m_4 ... ok
test range_proof::tests::create_and_verify_n_64_m_8 ... ok

test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.50s

     Running tests/range_proof.rs (/home/danda/dev/maidsafe/blst-bulletproofs/target/debug/deps/range_proof-66bae9ab4babc161)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests bulletproofs

running 2 tests
test src/range_proof/mod.rs - range_proof::RangeProof::prove_single_with_rng (line 84) ... ok
test src/range_proof/mod.rs - range_proof::RangeProof::prove_multiple_with_rng (line 184) ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.43s
```